### PR TITLE
Add redirect rule for beta

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,7 +18,7 @@
     object-src 'none';'''
 
 [[redirects]]
-  from = "https://demo.arcana.network/*"
+  from = "https://deploy-preview-48--arcana-demo-app.netlify.app/*"
   to = "https://demo.beta.arcana.network/*"
   status = 301
   force = true


### PR DESCRIPTION
Resolves [AR-3385](https://team-1624093970686.atlassian.net/browse/AR-3385).

Adds a redirect from https://demo.arcana.network to https://demo.beta.arcana.network. This is a temporary solution and should not be used long-term. It should only be used on the main branch.

cc: @lakshmikanthfang 