### PR TITLE
Fix error in parsing user info

### DIFF
--- a/src/use/arcanaWallet.js
+++ b/src/use/arcanaWallet.js
@@ -36,7 +36,7 @@ function useArcanaWallet() {
     store.dispatch("showFullScreenLoader", "Fetching account details...");
 
     const userInfo = await AuthService.requestUserInfo();
-    store.dispatch("addUserInfo", JSON.parse(userInfo));
+    store.dispatch("addUserInfo", userInfo);
 
     const [walletAddress] = await AuthService.requestWalletInfo();
     store.dispatch("addWalletInfo", { address: walletAddress });


### PR DESCRIPTION
Resolves [AR-3890](https://team-1624093970686.atlassian.net/browse/AR-3890)

## Change Summary

In https://github.com/arcana-network/wallet-ui/pull/56 we change the response returned by `getUserInfo` from a string to an object. This change removes the parsing code from demo app. 

## Checklist

- [x] The changes have been tested locally.
