### PR TITLE
pass did to onSuccess as param

### DIFF
--- a/src/services/storage.service.js
+++ b/src/services/storage.service.js
@@ -41,7 +41,7 @@ function createStorageService() {
   async function upload(fileBlob, { onSuccess, onError, onProgress }) {
     try {
       const fileDid = await storage.upload(fileBlob, onProgress);
-      onSuccess();
+      onSuccess(fileDid);
       return fileDid;
     } catch (error) {
       onError(error);

--- a/src/use/arcanaStorage.js
+++ b/src/use/arcanaStorage.js
@@ -83,7 +83,7 @@ function useArcanaStorage() {
           toastError(error.message);
           store.dispatch("hideInlineLoader");
         },
-        onSuccess: () => {
+        onSuccess: (did) => {
           fetchStorageLimits();
           toastSuccess("Upload success");
           let myFiles = [...store.getters.myFiles];


### PR DESCRIPTION
Issue: Error was thrown after successful upload of a file, found that DID is not passed to `onSuccess` fn.

## Change Summary

Passed DID to `onSuccess` fn

## Checklist

- [X] The changes have been tested locally.
