### PR TITLE
pass onProgress to object

### DIFF
--- a/src/services/storage.service.js
+++ b/src/services/storage.service.js
@@ -40,7 +40,7 @@ function createStorageService() {
 
   async function upload(fileBlob, { onSuccess, onError, onProgress }) {
     try {
-      const fileDid = await storage.upload(fileBlob, onProgress);
+      const fileDid = await storage.upload(fileBlob, { onProgress });
       onSuccess(fileDid);
       return fileDid;
     } catch (error) {


### PR DESCRIPTION
Issue: File size was not shown in the entries after successful downloads

## Change Summary

Has a call with @SauravKanchan and found that it should be passed as object, did the same.

## Checklist

- [X] The changes have been tested locally.
