### PR TITLE
Hotfix update sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "arcana-demo",
       "version": "0.0.0",
       "dependencies": {
-        "@arcana/auth": "^0.1.2-beta.12",
-        "@arcana/storage": "^0.3.6",
+        "@arcana/auth": "^0.1.2-beta.17",
+        "@arcana/storage": "^0.3.8",
         "@heroicons/vue": "^1.0.1",
         "@sentry/tracing": "^6.16.1",
         "@sentry/vue": "^6.16.1",
@@ -80,21 +80,15 @@
       }
     },
     "node_modules/@arcana/auth": {
-      "version": "0.1.2-beta.12",
-      "resolved": "https://registry.npmjs.org/@arcana/auth/-/auth-0.1.2-beta.12.tgz",
-      "integrity": "sha512-q4YBmjCOwmUMPGS4whDfzB2xnDmrwbJOixpWkOQW3ynYs1uYyuqbVki9vGvEHPfDyep+/SumU//3LS7lSm2Csg==",
+      "version": "0.1.2-beta.17",
+      "resolved": "https://registry.npmjs.org/@arcana/auth/-/auth-0.1.2-beta.17.tgz",
+      "integrity": "sha512-D7YQ2CL8xSxsEUrFfmZihm8zePKZ9Vg8lWfp5G0tFP1QwRDSAmN6GO2G1YTfDYN/4wJAl0pVVNVpWpndy6P9Rg==",
       "dependencies": {
         "@metamask/safe-event-emitter": "^2.0.0",
         "@sentry/browser": "^6.19.7",
         "@sentry/tracing": "^6.19.7",
-        "eth-block-tracker": "^5.0.1",
-        "eth-crypto": "^2.1.0",
-        "eth-json-rpc-middleware": "^8.0.1",
-        "eth-sig-util": "^3.0.1",
-        "ethers": "^5.5.4",
-        "json-rpc-engine": "^6.1.0",
-        "penpal": "^6.0.1",
-        "web3-providers-http": "^1.6.1"
+        "eth-rpc-errors": "^4.0.3",
+        "penpal": "^6.0.1"
       }
     },
     "node_modules/@arcana/auth/node_modules/@sentry/browser": {
@@ -173,9 +167,9 @@
       }
     },
     "node_modules/@arcana/storage": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@arcana/storage/-/storage-0.3.6.tgz",
-      "integrity": "sha512-3PY0s8AxJ4cHR2/zMWBDptWJgjGmeUwn8bet595L7enEadlxZJsdIcFiByerLz/xmyjmWBWiX3Utr4/259Qchg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@arcana/storage/-/storage-0.3.8.tgz",
+      "integrity": "sha512-Xm8dmlrlNpv6ORBCHgr2g7u6gZGUgHivVARMniqQSIEWhkkM+Ti5K4Q8JWGR8idonsoZeQYQcRMBloAMZHbaVQ==",
       "dependencies": {
         "@sentry/browser": "^6.15.0",
         "@sentry/tracing": "^6.15.0",
@@ -185,6 +179,7 @@
         "buffer": "^6.0.3",
         "eciesjs": "^0.3.14",
         "eth-sig-util": "^3.0.1",
+        "js-sha3": "^0.8.0",
         "shamir": "^0.7.1",
         "tus-js-client": "^2.3.1",
         "tweetnacl": "^1.0.3"
@@ -298,17 +293,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@css-render/plugin-bem": {
       "version": "0.15.6",
       "resolved": "https://registry.npmjs.org/@css-render/plugin-bem/-/plugin-bem-0.15.6.tgz",
@@ -332,39 +316,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
       "dev": true
-    },
-    "node_modules/@ethereumjs/common": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.5.tgz",
-      "integrity": "sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.1.5"
-      }
-    },
-    "node_modules/@ethereumjs/common/node_modules/ethereumjs-util": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@ethereumjs/tx": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.1.tgz",
-      "integrity": "sha512-xzDrTiu4sqZXUcaBxJ4n4W5FrppwxLxZB4ZDGVLtxSQR4lVuOnFR6RcUHdg1mpUhAPVrmnzLJpxaeXnPxIyhWA==",
-      "dependencies": {
-        "@ethereumjs/common": "^2.6.3",
-        "ethereumjs-util": "^7.1.4"
-      }
     },
     "node_modules/@ethersproject/abi": {
       "version": "5.6.3",
@@ -1256,14 +1207,6 @@
         "vue-router": "3.x || 4.x"
       }
     },
-    "node_modules/@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -1483,6 +1426,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
       "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1681,24 +1625,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
@@ -1788,17 +1714,6 @@
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -1940,14 +1855,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/color/-/color-4.0.2.tgz",
@@ -2010,11 +1917,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
-    },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -2029,17 +1931,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/create-hash": {
@@ -2203,61 +2094,6 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
     },
-    "node_modules/drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "optional": true,
-      "dependencies": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/eccrypto": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.6.tgz",
-      "integrity": "sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "acorn": "7.1.1",
-        "elliptic": "6.5.4",
-        "es6-promise": "4.2.8",
-        "nan": "2.14.0"
-      },
-      "optionalDependencies": {
-        "secp256k1": "3.7.1"
-      }
-    },
-    "node_modules/eccrypto/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "optional": true
-    },
-    "node_modules/eccrypto/node_modules/secp256k1": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.4.1",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/eciesjs": {
       "version": "0.3.15",
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.3.15.tgz",
@@ -2358,11 +2194,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/esbuild": {
       "version": "0.13.15",
@@ -2637,749 +2468,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
-    "node_modules/eth-block-tracker": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-5.0.1.tgz",
-      "integrity": "sha512-NVs+JDSux0FdmOrl3A2YDcQFkkYf9/qW9irvPmtC7bhMoPAe6oBlaqqe/m9Ixh5rkKqAox4mEyWGpsFmf/IsNw==",
-      "dependencies": {
-        "@metamask/safe-event-emitter": "^2.0.0",
-        "json-rpc-random-id": "^1.0.1",
-        "pify": "^3.0.0"
-      }
-    },
-    "node_modules/eth-crypto": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eth-crypto/-/eth-crypto-2.3.0.tgz",
-      "integrity": "sha512-kTRdMuqIO4OBuk5XKL3FNQ6HVQV54dc/mxGgSoeUscp+7eiZ3C5xBsBj2DGY2HM9Woa0sMuzvpi6HwjyXL6E8w==",
-      "dependencies": {
-        "@babel/runtime": "7.17.9",
-        "@ethereumjs/tx": "3.5.1",
-        "@types/bn.js": "5.1.0",
-        "eccrypto": "1.1.6",
-        "ethereumjs-util": "7.1.4",
-        "ethers": "5.6.4",
-        "secp256k1": "4.0.3"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/abi": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.1.tgz",
-      "integrity": "sha512-0cqssYh6FXjlwKWBmLm3+zH2BNARoS5u/hxbz+LpQmcDB3w0W553h2btWui1/uZp2GBM/SI3KniTuMcYyHpA5w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/abstract-provider": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz",
-      "integrity": "sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/web": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz",
-      "integrity": "sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/address": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.0.tgz",
-      "integrity": "sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/base64": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.0.tgz",
-      "integrity": "sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/basex": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.0.tgz",
-      "integrity": "sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/bignumber": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.0.tgz",
-      "integrity": "sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "bn.js": "^4.11.9"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/constants": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.0.tgz",
-      "integrity": "sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/contracts": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.0.tgz",
-      "integrity": "sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "^5.6.0",
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/hash": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.0.tgz",
-      "integrity": "sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/hdnode": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.0.tgz",
-      "integrity": "sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/basex": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0",
-        "@ethersproject/signing-key": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/wordlists": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/json-wallets": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz",
-      "integrity": "sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/hdnode": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/keccak256": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.0.tgz",
-      "integrity": "sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "js-sha3": "0.8.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/networks": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.2.tgz",
-      "integrity": "sha512-9uEzaJY7j5wpYGTojGp8U89mSsgQLc40PCMJLMCnFXTs7nhBveZ0t7dbqWUNrepWTszDbFkYD6WlL8DKx5huHA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/pbkdf2": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz",
-      "integrity": "sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/providers": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.4.tgz",
-      "integrity": "sha512-WAdknnaZ52hpHV3qPiJmKx401BLpup47h36Axxgre9zT+doa/4GC/Ne48ICPxTm0BqndpToHjpLP1ZnaxyE+vw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/basex": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/web": "^5.6.0",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/random": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.0.tgz",
-      "integrity": "sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/rlp": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
-      "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/sha2": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.0.tgz",
-      "integrity": "sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "hash.js": "1.1.7"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/signing-key": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.0.tgz",
-      "integrity": "sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "bn.js": "^4.11.9",
-        "elliptic": "6.5.4",
-        "hash.js": "1.1.7"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/solidity": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.0.tgz",
-      "integrity": "sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/strings": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
-      "integrity": "sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/transactions": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.0.tgz",
-      "integrity": "sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.0",
-        "@ethersproject/signing-key": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/units": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.0.tgz",
-      "integrity": "sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/wallet": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.0.tgz",
-      "integrity": "sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/hdnode": "^5.6.0",
-        "@ethersproject/json-wallets": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.0",
-        "@ethersproject/signing-key": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/wordlists": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/web": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.0.tgz",
-      "integrity": "sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/base64": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/wordlists": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.0.tgz",
-      "integrity": "sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/eth-crypto/node_modules/ethers": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.4.tgz",
-      "integrity": "sha512-62UIfxAQXdf67TeeOaoOoPctm5hUlYgfd0iW3wxfj7qRYKDcvvy0f+sJ3W2/Pyx77R8dblvejA8jokj+lS+ATQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "5.6.1",
-        "@ethersproject/abstract-provider": "5.6.0",
-        "@ethersproject/abstract-signer": "5.6.0",
-        "@ethersproject/address": "5.6.0",
-        "@ethersproject/base64": "5.6.0",
-        "@ethersproject/basex": "5.6.0",
-        "@ethersproject/bignumber": "5.6.0",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.0",
-        "@ethersproject/contracts": "5.6.0",
-        "@ethersproject/hash": "5.6.0",
-        "@ethersproject/hdnode": "5.6.0",
-        "@ethersproject/json-wallets": "5.6.0",
-        "@ethersproject/keccak256": "5.6.0",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.2",
-        "@ethersproject/pbkdf2": "5.6.0",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.4",
-        "@ethersproject/random": "5.6.0",
-        "@ethersproject/rlp": "5.6.0",
-        "@ethersproject/sha2": "5.6.0",
-        "@ethersproject/signing-key": "5.6.0",
-        "@ethersproject/solidity": "5.6.0",
-        "@ethersproject/strings": "5.6.0",
-        "@ethersproject/transactions": "5.6.0",
-        "@ethersproject/units": "5.6.0",
-        "@ethersproject/wallet": "5.6.0",
-        "@ethersproject/web": "5.6.0",
-        "@ethersproject/wordlists": "5.6.0"
-      }
-    },
-    "node_modules/eth-json-rpc-middleware": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-8.1.0.tgz",
-      "integrity": "sha512-0ZZDr6KoddqN4N100a7YWzLTYrVN0P49DJ3Su1vsRavPpieq92rgZymnQcr0tLFBQDEJg1MVqLex46fA0GEkDA==",
-      "dependencies": {
-        "@metamask/safe-event-emitter": "^2.0.0",
-        "btoa": "^1.2.1",
-        "clone": "^2.1.1",
-        "eth-block-tracker": "^5.0.1",
-        "eth-rpc-errors": "^4.0.3",
-        "eth-sig-util": "^1.4.2",
-        "json-rpc-engine": "^6.1.0",
-        "json-stable-stringify": "^1.0.1",
-        "node-fetch": "^2.6.7",
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/eth-json-rpc-middleware/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/eth-json-rpc-middleware/node_modules/eth-sig-util": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
-      "integrity": "sha512-iNZ576iTOGcfllftB73cPB5AN+XUQAT/T8xzsILsghXC1o8gJUqe3RHlcDqagu+biFpYQ61KQrZZJza8eRSYqw==",
-      "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
-      "dependencies": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-        "ethereumjs-util": "^5.1.1"
-      }
-    },
-    "node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-util": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-      "dependencies": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "^0.1.3",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "node_modules/eth-rpc-errors": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
@@ -3417,14 +2505,6 @@
         "ethjs-util": "^0.1.3",
         "rlp": "^2.0.0",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/ethereum-bloom-filters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
-      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
-      "dependencies": {
-        "js-sha3": "^0.8.0"
       }
     },
     "node_modules/ethereum-cryptography": {
@@ -3485,21 +2565,6 @@
         "rlp": "^2.2.3"
       }
     },
-    "node_modules/ethereumjs-util": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-      "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/ethers": {
       "version": "5.6.8",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.8.tgz",
@@ -3546,24 +2611,6 @@
         "@ethersproject/web": "5.6.1",
         "@ethersproject/wordlists": "5.6.1"
       }
-    },
-    "node_modules/ethjs-unit": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "number-to-bn": "1.7.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-unit/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
     },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
@@ -3639,12 +2686,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -4406,31 +3447,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-rpc-engine": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
-      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
-      "dependencies": {
-        "@metamask/safe-event-emitter": "^2.0.0",
-        "eth-rpc-errors": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/json-rpc-random-id": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
-      "integrity": "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA=="
-    },
-    "node_modules/json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
-      "dependencies": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -4441,14 +3457,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/keccak": {
@@ -4669,11 +3677,6 @@
         "vue": "^3.0.0"
       }
     },
-    "node_modules/nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-    },
     "node_modules/nanoid": {
       "version": "3.1.30",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
@@ -4697,25 +3700,6 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-gyp-build": {
@@ -4751,24 +3735,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/number-to-bn/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
     },
     "node_modules/object-hash": {
       "version": "2.2.0",
@@ -4925,14 +3891,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/postcss": {
@@ -5192,11 +4150,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -5601,11 +4554,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/treemate": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/treemate/-/treemate-0.3.8.tgz",
@@ -5672,11 +4620,6 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "node_modules/utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "node_modules/util": {
       "version": "0.12.4",
@@ -5838,73 +4781,6 @@
         "vue": "^3.0.2"
       }
     },
-    "node_modules/web3-core-helpers": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.4.tgz",
-      "integrity": "sha512-F8PH11qIkE/LpK4/h1fF/lGYgt4B6doeMi8rukeV/s4ivseZHHslv1L6aaijLX/g/j4PsFmR42byynBI/MIzFg==",
-      "dependencies": {
-        "web3-eth-iban": "1.7.4",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-eth-iban": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.4.tgz",
-      "integrity": "sha512-XyrsgWlZQMv5gRcjXMsNvAoCRvV5wN7YCfFV5+tHUCqN8g9T/o4XUS20vDWD0k4HNiAcWGFqT1nrls02MGZ08w==",
-      "dependencies": {
-        "bn.js": "^5.2.1",
-        "web3-utils": "1.7.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-providers-http": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.4.tgz",
-      "integrity": "sha512-AU+/S+49rcogUER99TlhW+UBMk0N2DxvN54CJ2pK7alc2TQ7+cprNPLHJu4KREe8ndV0fT6JtWUfOMyTvl+FRA==",
-      "dependencies": {
-        "web3-core-helpers": "1.7.4",
-        "xhr2-cookies": "1.1.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/web3-utils": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
-      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
-      "dependencies": {
-        "bn.js": "^5.2.1",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
@@ -5965,14 +4841,6 @@
         }
       }
     },
-    "node_modules/xhr2-cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-      "integrity": "sha512-hjXUA6q+jl/bd8ADHcVfFsSPIf+tyLIjuO9TwJC9WI6JP2zKcS7C+p56I9kCLLsaCiNT035iYvEUUzdEFj/8+g==",
-      "dependencies": {
-        "cookiejar": "^2.1.1"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -5994,21 +4862,15 @@
   },
   "dependencies": {
     "@arcana/auth": {
-      "version": "0.1.2-beta.12",
-      "resolved": "https://registry.npmjs.org/@arcana/auth/-/auth-0.1.2-beta.12.tgz",
-      "integrity": "sha512-q4YBmjCOwmUMPGS4whDfzB2xnDmrwbJOixpWkOQW3ynYs1uYyuqbVki9vGvEHPfDyep+/SumU//3LS7lSm2Csg==",
+      "version": "0.1.2-beta.17",
+      "resolved": "https://registry.npmjs.org/@arcana/auth/-/auth-0.1.2-beta.17.tgz",
+      "integrity": "sha512-D7YQ2CL8xSxsEUrFfmZihm8zePKZ9Vg8lWfp5G0tFP1QwRDSAmN6GO2G1YTfDYN/4wJAl0pVVNVpWpndy6P9Rg==",
       "requires": {
         "@metamask/safe-event-emitter": "^2.0.0",
         "@sentry/browser": "^6.19.7",
         "@sentry/tracing": "^6.19.7",
-        "eth-block-tracker": "^5.0.1",
-        "eth-crypto": "^2.1.0",
-        "eth-json-rpc-middleware": "^8.0.1",
-        "eth-sig-util": "^3.0.1",
-        "ethers": "^5.5.4",
-        "json-rpc-engine": "^6.1.0",
-        "penpal": "^6.0.1",
-        "web3-providers-http": "^1.6.1"
+        "eth-rpc-errors": "^4.0.3",
+        "penpal": "^6.0.1"
       },
       "dependencies": {
         "@sentry/browser": {
@@ -6071,9 +4933,9 @@
       }
     },
     "@arcana/storage": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@arcana/storage/-/storage-0.3.6.tgz",
-      "integrity": "sha512-3PY0s8AxJ4cHR2/zMWBDptWJgjGmeUwn8bet595L7enEadlxZJsdIcFiByerLz/xmyjmWBWiX3Utr4/259Qchg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@arcana/storage/-/storage-0.3.8.tgz",
+      "integrity": "sha512-Xm8dmlrlNpv6ORBCHgr2g7u6gZGUgHivVARMniqQSIEWhkkM+Ti5K4Q8JWGR8idonsoZeQYQcRMBloAMZHbaVQ==",
       "requires": {
         "@sentry/browser": "^6.15.0",
         "@sentry/tracing": "^6.15.0",
@@ -6083,6 +4945,7 @@
         "buffer": "^6.0.3",
         "eciesjs": "^0.3.14",
         "eth-sig-util": "^3.0.1",
+        "js-sha3": "^0.8.0",
         "shamir": "^0.7.1",
         "tus-js-client": "^2.3.1",
         "tweetnacl": "^1.0.3"
@@ -6171,14 +5034,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
       "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng=="
     },
-    "@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@css-render/plugin-bem": {
       "version": "0.15.6",
       "resolved": "https://registry.npmjs.org/@css-render/plugin-bem/-/plugin-bem-0.15.6.tgz",
@@ -6200,38 +5055,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
       "dev": true
-    },
-    "@ethereumjs/common": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.5.tgz",
-      "integrity": "sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==",
-      "requires": {
-        "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.1.5"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-          "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          }
-        }
-      }
-    },
-    "@ethereumjs/tx": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.1.tgz",
-      "integrity": "sha512-xzDrTiu4sqZXUcaBxJ4n4W5FrppwxLxZB4ZDGVLtxSQR4lVuOnFR6RcUHdg1mpUhAPVrmnzLJpxaeXnPxIyhWA==",
-      "requires": {
-        "@ethereumjs/common": "^2.6.3",
-        "ethereumjs-util": "^7.1.4"
-      }
     },
     "@ethersproject/abi": {
       "version": "5.6.3",
@@ -6771,14 +5594,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -6991,7 +5806,8 @@
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -7135,24 +5951,6 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
@@ -7230,11 +6028,6 @@
         "create-hash": "^1.1.0",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer": {
       "version": "6.0.3",
@@ -7333,11 +6126,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
-    },
     "color": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/color/-/color-4.0.2.tgz",
@@ -7394,11 +6182,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
-    },
     "cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -7411,11 +6194,6 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
-    },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "create-hash": {
       "version": "1.2.0",
@@ -7547,53 +6325,6 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
     },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "optional": true,
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
-    "eccrypto": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.6.tgz",
-      "integrity": "sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==",
-      "requires": {
-        "acorn": "7.1.1",
-        "elliptic": "6.5.4",
-        "es6-promise": "4.2.8",
-        "nan": "2.14.0",
-        "secp256k1": "3.7.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "optional": true
-        },
-        "secp256k1": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-          "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.4.1",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
-        }
-      }
-    },
     "eciesjs": {
       "version": "0.3.15",
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.3.15.tgz",
@@ -7684,11 +6415,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "esbuild": {
       "version": "0.13.15",
@@ -7851,469 +6577,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
-    "eth-block-tracker": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-5.0.1.tgz",
-      "integrity": "sha512-NVs+JDSux0FdmOrl3A2YDcQFkkYf9/qW9irvPmtC7bhMoPAe6oBlaqqe/m9Ixh5rkKqAox4mEyWGpsFmf/IsNw==",
-      "requires": {
-        "@metamask/safe-event-emitter": "^2.0.0",
-        "json-rpc-random-id": "^1.0.1",
-        "pify": "^3.0.0"
-      }
-    },
-    "eth-crypto": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eth-crypto/-/eth-crypto-2.3.0.tgz",
-      "integrity": "sha512-kTRdMuqIO4OBuk5XKL3FNQ6HVQV54dc/mxGgSoeUscp+7eiZ3C5xBsBj2DGY2HM9Woa0sMuzvpi6HwjyXL6E8w==",
-      "requires": {
-        "@babel/runtime": "7.17.9",
-        "@ethereumjs/tx": "3.5.1",
-        "@types/bn.js": "5.1.0",
-        "eccrypto": "1.1.6",
-        "ethereumjs-util": "7.1.4",
-        "ethers": "5.6.4",
-        "secp256k1": "4.0.3"
-      },
-      "dependencies": {
-        "@ethersproject/abi": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.1.tgz",
-          "integrity": "sha512-0cqssYh6FXjlwKWBmLm3+zH2BNARoS5u/hxbz+LpQmcDB3w0W553h2btWui1/uZp2GBM/SI3KniTuMcYyHpA5w==",
-          "requires": {
-            "@ethersproject/address": "^5.6.0",
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/constants": "^5.6.0",
-            "@ethersproject/hash": "^5.6.0",
-            "@ethersproject/keccak256": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/strings": "^5.6.0"
-          }
-        },
-        "@ethersproject/abstract-provider": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz",
-          "integrity": "sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/networks": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/transactions": "^5.6.0",
-            "@ethersproject/web": "^5.6.0"
-          }
-        },
-        "@ethersproject/abstract-signer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz",
-          "integrity": "sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.6.0",
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
-          }
-        },
-        "@ethersproject/address": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.0.tgz",
-          "integrity": "sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/keccak256": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/rlp": "^5.6.0"
-          }
-        },
-        "@ethersproject/base64": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.0.tgz",
-          "integrity": "sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0"
-          }
-        },
-        "@ethersproject/basex": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.0.tgz",
-          "integrity": "sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.0.tgz",
-          "integrity": "sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "bn.js": "^4.11.9"
-          }
-        },
-        "@ethersproject/constants": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.0.tgz",
-          "integrity": "sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.6.0"
-          }
-        },
-        "@ethersproject/contracts": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.0.tgz",
-          "integrity": "sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==",
-          "requires": {
-            "@ethersproject/abi": "^5.6.0",
-            "@ethersproject/abstract-provider": "^5.6.0",
-            "@ethersproject/abstract-signer": "^5.6.0",
-            "@ethersproject/address": "^5.6.0",
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/constants": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/transactions": "^5.6.0"
-          }
-        },
-        "@ethersproject/hash": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.0.tgz",
-          "integrity": "sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==",
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.6.0",
-            "@ethersproject/address": "^5.6.0",
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/keccak256": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/strings": "^5.6.0"
-          }
-        },
-        "@ethersproject/hdnode": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.0.tgz",
-          "integrity": "sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==",
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.6.0",
-            "@ethersproject/basex": "^5.6.0",
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/pbkdf2": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/sha2": "^5.6.0",
-            "@ethersproject/signing-key": "^5.6.0",
-            "@ethersproject/strings": "^5.6.0",
-            "@ethersproject/transactions": "^5.6.0",
-            "@ethersproject/wordlists": "^5.6.0"
-          }
-        },
-        "@ethersproject/json-wallets": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz",
-          "integrity": "sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==",
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.6.0",
-            "@ethersproject/address": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/hdnode": "^5.6.0",
-            "@ethersproject/keccak256": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/pbkdf2": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/random": "^5.6.0",
-            "@ethersproject/strings": "^5.6.0",
-            "@ethersproject/transactions": "^5.6.0",
-            "aes-js": "3.0.0",
-            "scrypt-js": "3.0.1"
-          }
-        },
-        "@ethersproject/keccak256": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.0.tgz",
-          "integrity": "sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "js-sha3": "0.8.0"
-          }
-        },
-        "@ethersproject/networks": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.2.tgz",
-          "integrity": "sha512-9uEzaJY7j5wpYGTojGp8U89mSsgQLc40PCMJLMCnFXTs7nhBveZ0t7dbqWUNrepWTszDbFkYD6WlL8DKx5huHA==",
-          "requires": {
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/pbkdf2": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz",
-          "integrity": "sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/sha2": "^5.6.0"
-          }
-        },
-        "@ethersproject/providers": {
-          "version": "5.6.4",
-          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.4.tgz",
-          "integrity": "sha512-WAdknnaZ52hpHV3qPiJmKx401BLpup47h36Axxgre9zT+doa/4GC/Ne48ICPxTm0BqndpToHjpLP1ZnaxyE+vw==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.6.0",
-            "@ethersproject/abstract-signer": "^5.6.0",
-            "@ethersproject/address": "^5.6.0",
-            "@ethersproject/basex": "^5.6.0",
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/constants": "^5.6.0",
-            "@ethersproject/hash": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/networks": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/random": "^5.6.0",
-            "@ethersproject/rlp": "^5.6.0",
-            "@ethersproject/sha2": "^5.6.0",
-            "@ethersproject/strings": "^5.6.0",
-            "@ethersproject/transactions": "^5.6.0",
-            "@ethersproject/web": "^5.6.0",
-            "bech32": "1.1.4",
-            "ws": "7.4.6"
-          }
-        },
-        "@ethersproject/random": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.0.tgz",
-          "integrity": "sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/rlp": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
-          "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/sha2": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.0.tgz",
-          "integrity": "sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "hash.js": "1.1.7"
-          }
-        },
-        "@ethersproject/signing-key": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.0.tgz",
-          "integrity": "sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "bn.js": "^4.11.9",
-            "elliptic": "6.5.4",
-            "hash.js": "1.1.7"
-          }
-        },
-        "@ethersproject/solidity": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.0.tgz",
-          "integrity": "sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/keccak256": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/sha2": "^5.6.0",
-            "@ethersproject/strings": "^5.6.0"
-          }
-        },
-        "@ethersproject/strings": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
-          "integrity": "sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/constants": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.0.tgz",
-          "integrity": "sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==",
-          "requires": {
-            "@ethersproject/address": "^5.6.0",
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/constants": "^5.6.0",
-            "@ethersproject/keccak256": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/rlp": "^5.6.0",
-            "@ethersproject/signing-key": "^5.6.0"
-          }
-        },
-        "@ethersproject/units": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.0.tgz",
-          "integrity": "sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/constants": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0"
-          }
-        },
-        "@ethersproject/wallet": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.0.tgz",
-          "integrity": "sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.6.0",
-            "@ethersproject/abstract-signer": "^5.6.0",
-            "@ethersproject/address": "^5.6.0",
-            "@ethersproject/bignumber": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/hash": "^5.6.0",
-            "@ethersproject/hdnode": "^5.6.0",
-            "@ethersproject/json-wallets": "^5.6.0",
-            "@ethersproject/keccak256": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/random": "^5.6.0",
-            "@ethersproject/signing-key": "^5.6.0",
-            "@ethersproject/transactions": "^5.6.0",
-            "@ethersproject/wordlists": "^5.6.0"
-          }
-        },
-        "@ethersproject/web": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.0.tgz",
-          "integrity": "sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==",
-          "requires": {
-            "@ethersproject/base64": "^5.6.0",
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/strings": "^5.6.0"
-          }
-        },
-        "@ethersproject/wordlists": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.0.tgz",
-          "integrity": "sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==",
-          "requires": {
-            "@ethersproject/bytes": "^5.6.0",
-            "@ethersproject/hash": "^5.6.0",
-            "@ethersproject/logger": "^5.6.0",
-            "@ethersproject/properties": "^5.6.0",
-            "@ethersproject/strings": "^5.6.0"
-          }
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethers": {
-          "version": "5.6.4",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.4.tgz",
-          "integrity": "sha512-62UIfxAQXdf67TeeOaoOoPctm5hUlYgfd0iW3wxfj7qRYKDcvvy0f+sJ3W2/Pyx77R8dblvejA8jokj+lS+ATQ==",
-          "requires": {
-            "@ethersproject/abi": "5.6.1",
-            "@ethersproject/abstract-provider": "5.6.0",
-            "@ethersproject/abstract-signer": "5.6.0",
-            "@ethersproject/address": "5.6.0",
-            "@ethersproject/base64": "5.6.0",
-            "@ethersproject/basex": "5.6.0",
-            "@ethersproject/bignumber": "5.6.0",
-            "@ethersproject/bytes": "5.6.1",
-            "@ethersproject/constants": "5.6.0",
-            "@ethersproject/contracts": "5.6.0",
-            "@ethersproject/hash": "5.6.0",
-            "@ethersproject/hdnode": "5.6.0",
-            "@ethersproject/json-wallets": "5.6.0",
-            "@ethersproject/keccak256": "5.6.0",
-            "@ethersproject/logger": "5.6.0",
-            "@ethersproject/networks": "5.6.2",
-            "@ethersproject/pbkdf2": "5.6.0",
-            "@ethersproject/properties": "5.6.0",
-            "@ethersproject/providers": "5.6.4",
-            "@ethersproject/random": "5.6.0",
-            "@ethersproject/rlp": "5.6.0",
-            "@ethersproject/sha2": "5.6.0",
-            "@ethersproject/signing-key": "5.6.0",
-            "@ethersproject/solidity": "5.6.0",
-            "@ethersproject/strings": "5.6.0",
-            "@ethersproject/transactions": "5.6.0",
-            "@ethersproject/units": "5.6.0",
-            "@ethersproject/wallet": "5.6.0",
-            "@ethersproject/web": "5.6.0",
-            "@ethersproject/wordlists": "5.6.0"
-          }
-        }
-      }
-    },
-    "eth-json-rpc-middleware": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-8.1.0.tgz",
-      "integrity": "sha512-0ZZDr6KoddqN4N100a7YWzLTYrVN0P49DJ3Su1vsRavPpieq92rgZymnQcr0tLFBQDEJg1MVqLex46fA0GEkDA==",
-      "requires": {
-        "@metamask/safe-event-emitter": "^2.0.0",
-        "btoa": "^1.2.1",
-        "clone": "^2.1.1",
-        "eth-block-tracker": "^5.0.1",
-        "eth-rpc-errors": "^4.0.3",
-        "eth-sig-util": "^1.4.2",
-        "json-rpc-engine": "^6.1.0",
-        "json-stable-stringify": "^1.0.1",
-        "node-fetch": "^2.6.7",
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "eth-sig-util": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
-          "integrity": "sha512-iNZ576iTOGcfllftB73cPB5AN+XUQAT/T8xzsILsghXC1o8gJUqe3RHlcDqagu+biFpYQ61KQrZZJza8eRSYqw==",
-          "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-            "ethereumjs-util": "^5.1.1"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        }
-      }
-    },
     "eth-rpc-errors": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
@@ -8352,14 +6615,6 @@
             "safe-buffer": "^5.1.1"
           }
         }
-      }
-    },
-    "ethereum-bloom-filters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
-      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
-      "requires": {
-        "js-sha3": "^0.8.0"
       }
     },
     "ethereum-cryptography": {
@@ -8421,18 +6676,6 @@
         }
       }
     },
-    "ethereumjs-util": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-      "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-      "requires": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      }
-    },
     "ethers": {
       "version": "5.6.8",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.8.tgz",
@@ -8468,22 +6711,6 @@
         "@ethersproject/wallet": "5.6.2",
         "@ethersproject/web": "5.6.1",
         "@ethersproject/wordlists": "5.6.1"
-      }
-    },
-    "ethjs-unit": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
-      "requires": {
-        "bn.js": "4.11.6",
-        "number-to-bn": "1.7.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
-        }
       }
     },
     "ethjs-util": {
@@ -8552,12 +6779,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -9080,28 +7301,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "json-rpc-engine": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
-      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
-      "requires": {
-        "@metamask/safe-event-emitter": "^2.0.0",
-        "eth-rpc-errors": "^4.0.2"
-      }
-    },
-    "json-rpc-random-id": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
-      "integrity": "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA=="
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -9111,11 +7310,6 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA=="
     },
     "keccak": {
       "version": "3.0.2",
@@ -9307,11 +7501,6 @@
         "vueuc": "^0.4.18"
       }
     },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-    },
     "nanoid": {
       "version": "3.1.30",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
@@ -9329,14 +7518,6 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
       }
     },
     "node-gyp-build": {
@@ -9361,22 +7542,6 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
-    },
-    "number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
-      "requires": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
-        }
-      }
     },
     "object-hash": {
       "version": "2.2.0",
@@ -9489,11 +7654,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
-    },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="
     },
     "postcss": {
       "version": "8.4.4",
@@ -9670,11 +7830,6 @@
           "dev": true
         }
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -9973,11 +8128,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "treemate": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/treemate/-/treemate-0.3.8.tgz",
@@ -10038,11 +8188,6 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "util": {
       "version": "0.12.4",
@@ -10162,61 +8307,6 @@
         "@vue/devtools-api": "^6.0.0-beta.11"
       }
     },
-    "web3-core-helpers": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.4.tgz",
-      "integrity": "sha512-F8PH11qIkE/LpK4/h1fF/lGYgt4B6doeMi8rukeV/s4ivseZHHslv1L6aaijLX/g/j4PsFmR42byynBI/MIzFg==",
-      "requires": {
-        "web3-eth-iban": "1.7.4",
-        "web3-utils": "1.7.4"
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.4.tgz",
-      "integrity": "sha512-XyrsgWlZQMv5gRcjXMsNvAoCRvV5wN7YCfFV5+tHUCqN8g9T/o4XUS20vDWD0k4HNiAcWGFqT1nrls02MGZ08w==",
-      "requires": {
-        "bn.js": "^5.2.1",
-        "web3-utils": "1.7.4"
-      }
-    },
-    "web3-providers-http": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.4.tgz",
-      "integrity": "sha512-AU+/S+49rcogUER99TlhW+UBMk0N2DxvN54CJ2pK7alc2TQ7+cprNPLHJu4KREe8ndV0fT6JtWUfOMyTvl+FRA==",
-      "requires": {
-        "web3-core-helpers": "1.7.4",
-        "xhr2-cookies": "1.1.0"
-      }
-    },
-    "web3-utils": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.4.tgz",
-      "integrity": "sha512-acBdm6Evd0TEZRnChM/MCvGsMwYKmSh7OaUfNf5OKG0CIeGWD/6gqLOWIwmwSnre/2WrA1nKGId5uW2e5EfluA==",
-      "requires": {
-        "bn.js": "^5.2.1",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "which-boxed-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
@@ -10253,14 +8343,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "requires": {}
-    },
-    "xhr2-cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-      "integrity": "sha512-hjXUA6q+jl/bd8ADHcVfFsSPIf+tyLIjuO9TwJC9WI6JP2zKcS7C+p56I9kCLLsaCiNT035iYvEUUzdEFj/8+g==",
-      "requires": {
-        "cookiejar": "^2.1.1"
-      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@arcana/auth": "^0.1.2-beta.12",
-    "@arcana/storage": "^0.3.6",
+    "@arcana/auth": "^0.1.2-beta.17",
+    "@arcana/storage": "^0.3.8",
     "@heroicons/vue": "^1.0.1",
     "@sentry/tracing": "^6.16.1",
     "@sentry/vue": "^6.16.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,7 @@
 <template>
   <fullsize-background>
-    <full-screen-loader
-      v-if="isLoadingFullScreen || !isAppInitialised"
-      :key="'arcana-demo-app-loader'"
-      :message="fullScreenLoadingMessage"
-    />
+    <full-screen-loader v-if="isLoadingFullScreen || !isAppInitialised" :key="'arcana-demo-app-loader'"
+      :message="fullScreenLoadingMessage" />
     <div v-else="isAppInitialised">
       <app-sidebar v-if="$route.name !== 'Login'" />
       <router-view />
@@ -39,12 +36,15 @@ export default {
       await initWallet();
       const hasLoggedIn = await isLoggedIn();
       if (hasLoggedIn) {
-        await fetchUserDetails();
+        store.dispatch("showFullScreenLoader", "Fetching account details...");
+        setTimeout(async () => {
+          await fetchUserDetails();
 
-        if (route.path === "/login") {
-          await router.push("/my-files");
-          toastSuccess("Login Success");
-        }
+          if (route.path === "/login") {
+            await router.push("/my-files");
+            toastSuccess("Login Success");
+          }
+        }, 500)
       } else {
         await router.push("/login");
       }

--- a/src/components/FilesList.vue
+++ b/src/components/FilesList.vue
@@ -1,15 +1,12 @@
 <template>
   <div class="mt-6 mx-6 lg:mx-16">
     <div class="flex items-center justify-between">
-      <div
-        class="inline-block px-6 py-1 font-bold"
-        style="
+      <div class="inline-block px-6 py-1 font-bold" style="
           background: #eef1f6;
           font-size: 0.9rem;
           border-radius: 12px;
           color: #4b4b4b;
-        "
-      >
+        ">
         {{ pageTitle }}
       </div>
       <div>
@@ -17,24 +14,17 @@
       </div>
     </div>
     <div v-if="!files.length">
-      <div
-        class="absolute inline-block top-1/2 left-1/2 font-bold text-center"
-        style="
+      <div class="absolute inline-block top-1/2 left-1/2 font-bold text-center" style="
           transform: translate(-50%, -50%);
           color: #bcb8b8;
           font-size: 1.15rem;
-        "
-      >
-        <img
-          class="inline-block mb-2"
-          src="@/assets/file-icon.png"
-          style="
+        ">
+        <img class="inline-block mb-2" src="@/assets/file-icon.png" style="
             min-width: 160px;
             max-width: 300px;
             width: 22%;
             filter: invert(5%);
-          "
-        />
+          " />
         <br />
         <span v-if="pageTitle === 'My Files'">Upload a file to begin</span>
         <span v-else-if="pageTitle === 'Shared With Me'">
@@ -44,11 +34,7 @@
       </div>
     </div>
     <div v-else class="mt-6">
-      <div
-        v-if="listType === 'table'"
-        class="overflow-x-auto transition-fade lg:mb-20 mb-20"
-        style="min-width: 200px"
-      >
+      <div v-if="listType === 'table'" class="overflow-x-auto transition-fade lg:mb-20 mb-20" style="min-width: 200px">
         <table style="min-width: 100%; width: max-content" class="font-bold">
           <thead style="color: #b9b8b8">
             <tr>
@@ -65,18 +51,12 @@
             </tr>
           </thead>
           <tbody style="color: #707070">
-            <tr
-              v-for="file in files"
-              :key="file.fileId"
-              style="border-bottom: 2px solid #a1cdf8"
-            >
+            <tr v-for="file in files" :key="file.fileId" style="border-bottom: 2px solid #a1cdf8">
               <td class="pt-6 pb-3" style="width: calc(10vw + 3em)">
                 <n-tooltip trigger="hover">
                   <template #trigger>
-                    <span
-                      class="inline-block overflow-ellipsis overflow-hidden whitespace-nowrap pr-3 align-middle"
-                      style="width: 14vw; max-width: max-content"
-                    >
+                    <span class="inline-block overflow-ellipsis overflow-hidden whitespace-nowrap pr-3 align-middle"
+                      style="width: 14vw; max-width: max-content">
                       {{ file.fileId }}
                     </span>
                   </template>
@@ -84,9 +64,7 @@
                 </n-tooltip>
                 <n-tooltip trigger="hover">
                   <template #trigger>
-                    <InformationCircleIcon
-                      class="h-5 w-5 inline-block cursor-pointer outline-none"
-                    />
+                    <InformationCircleIcon class="h-5 w-5 inline-block cursor-pointer outline-none" />
                   </template>
                   Pseudonymous File ID
                 </n-tooltip>
@@ -99,20 +77,10 @@
               </td>
               <td>
                 <div class="mt-2 py-2 text-right">
-                  <n-tooltip
-                    trigger="hover"
-                    v-for="item in menuItems"
-                    :key="item.label + '-action'"
-                  >
+                  <n-tooltip trigger="hover" v-for="item in menuItems" :key="item.label + '-action'">
                     <template #trigger>
-                      <span
-                        class="file-menu inline-block"
-                        @click.stop="item.command(file)"
-                      >
-                        <component
-                          :is="item.icon"
-                          class="w-5 inline-block m-2"
-                        />
+                      <span class="file-menu inline-block" @click.stop="item.command(file)">
+                        <component :is="item.icon" class="w-5 inline-block m-2" />
                       </span>
                     </template>
                     {{ item.label }}
@@ -130,30 +98,17 @@
     <h3 class="font-ubuntu font-bold" style="color: #253d52; font-size: 1.5em">
       Share file
     </h3>
-    <label
-      class="block mt-4 mb-2 font-semibold"
-      for="recipient-email"
-      style="color: #707070; font-size: 1.2em"
-    >
+    <label class="block mt-4 mb-2 font-semibold" for="recipient-email" style="color: #707070; font-size: 1.2em">
       Recipient Email
     </label>
-    <input
-      type="email"
-      id="recipient-email"
-      v-model="shareEmail"
-      class="focus:outline-none rounded-full px-4 py-2 w-full"
-    />
+    <input type="email" id="recipient-email" v-model="shareEmail"
+      class="focus:outline-none rounded-full px-4 py-2 w-full" />
     <div class="text-center mt-5 mb-3">
-      <button
-        class="focus:outline-none py-2 px-5 rounded-full font-bold shadow-2xl"
-        :class="!isShareEmailInvalid ? 'cursor-pointer' : 'cursor-not-allowed'"
-        :style="{
+      <button class="focus:outline-none py-2 px-5 rounded-full font-bold shadow-2xl"
+        :class="!isShareEmailInvalid ? 'cursor-pointer' : 'cursor-not-allowed'" :style="{
           background: !isShareEmailInvalid ? '#058aff' : '#a1cdf8',
           color: 'white',
-        }"
-        :disabled="isShareEmailInvalid"
-        @click.stop="shareFile"
-      >
+        }" :disabled="isShareEmailInvalid" @click.stop="shareFile">
         Share
       </button>
     </div>
@@ -163,32 +118,18 @@
     <h3 class="font-ubuntu font-bold" style="color: #253d52; font-size: 1.5em">
       Transfer file ownership
     </h3>
-    <label
-      class="block mt-4 mb-2 font-semibold"
-      for="transfer-email"
-      style="color: #707070; font-size: 1.2em"
-    >
+    <label class="block mt-4 mb-2 font-semibold" for="transfer-email" style="color: #707070; font-size: 1.2em">
       Recipient Email
     </label>
-    <input
-      type="email"
-      id="transfer-email"
-      v-model="transferEmail"
-      class="focus:outline-none rounded-full px-4 py-2 w-full"
-    />
+    <input type="email" id="transfer-email" v-model="transferEmail"
+      class="focus:outline-none rounded-full px-4 py-2 w-full" />
     <div class="text-center mt-5 mb-3">
-      <button
-        class="focus:outline-none py-2 px-5 rounded-full font-bold shadow-2xl"
-        :class="
-          !isTransferEmailInvalid ? 'cursor-pointer' : 'cursor-not-allowed'
-        "
-        :style="{
-          background: !isTransferEmailInvalid ? '#058aff' : '#a1cdf8',
-          color: 'white',
-        }"
-        :disabled="isTransferEmailInvalid"
-        @click.stop="transferFile"
-      >
+      <button class="focus:outline-none py-2 px-5 rounded-full font-bold shadow-2xl" :class="
+        !isTransferEmailInvalid ? 'cursor-pointer' : 'cursor-not-allowed'
+      " :style="{
+        background: !isTransferEmailInvalid ? '#058aff' : '#a1cdf8',
+        color: 'white',
+      }" :disabled="isTransferEmailInvalid" @click.stop="transferFile">
         Transfer
       </button>
     </div>
@@ -198,23 +139,12 @@
     <h3 class="font-ubuntu font-bold" style="color: #253d52; font-size: 1.5em">
       List of user addresses
     </h3>
-    <ul
-      v-if="sharedUsers.users?.length"
-      class="my-3 overflow-y-auto overflow-hidden"
-      style="max-height: 60vh"
-    >
-      <li
-        v-for="user in sharedUsers.users"
-        :key="user"
-        class="py-3"
-        style="border-bottom: 2px solid #a1cdf8"
-      >
+    <ul v-if="sharedUsers.users?.length" class="my-3 overflow-y-auto overflow-hidden" style="max-height: 60vh">
+      <li v-for="user in sharedUsers.users" :key="user" class="py-3" style="border-bottom: 2px solid #a1cdf8">
         <n-tooltip trigger="hover">
           <template #trigger>
-            <span
-              class="inline-block overflow-hidden overflow-ellipsis align-middle font-black text-base"
-              style="width: calc(100% - 2em); color: #707070"
-            >
+            <span class="inline-block overflow-hidden overflow-ellipsis align-middle font-black text-base"
+              style="width: calc(100% - 2em); color: #707070">
               {{ user }}
             </span>
           </template>
@@ -222,10 +152,8 @@
         </n-tooltip>
         <n-tooltip trigger="hover">
           <template #trigger>
-            <BackspaceIcon
-              class="inline-block h-6 w-6 cursor-pointer ml-1 outline-none"
-              @click.stop="revokeAccess(sharedUsers.file, user)"
-            />
+            <BackspaceIcon class="inline-block h-6 w-6 cursor-pointer ml-1 outline-none"
+              @click.stop="revokeAccess(sharedUsers.file, user)" />
           </template>
           Revoke Access
         </n-tooltip>
@@ -335,7 +263,7 @@ export default {
     const transferEmail = ref("");
     const isTransferEmailInvalid = ref(true);
 
-    const { download, remove, share, revoke, getSharedUsers, changeFileOwner } =
+    const { download, remove, share, revoke, getSharedUsers, changeOwner } =
       useArcanaStorage();
     const GENESIS_ADDRESS = "0x0000000000000000000000000000000000000000";
 
@@ -390,13 +318,13 @@ export default {
     menuItem.recover = {
       label: "Recover",
       icon: RefreshIcon,
-      command: () => {},
+      command: () => { },
     };
 
     menuItem.delete = {
       label: "Delete Forever",
       icon: XCircleIcon,
-      command: () => {},
+      command: () => { },
     };
 
     menuItem.transfer = {
@@ -498,7 +426,7 @@ export default {
 
     async function transferFile() {
       const email = transferEmail.value.trim();
-      await changeFileOwner(fileToTransfer, email);
+      await changeOwner(fileToTransfer, email);
       closeDialog();
     }
 

--- a/src/pages/AppLogin.vue
+++ b/src/pages/AppLogin.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="bg-white absolute login-container p-10 text-center">
-    <img
-      src="@/assets/rocket-science.png"
-      style="height: 120px; display: inline"
-    />
+    <img src="@/assets/rocket-science.png" style="height: 120px; display: inline" />
     <div class="inline-block mt-12">
       By clicking on signin with google, you agree to Arcana Network's
       <a href="/" style="color: #058aff; text-decoration: none"> Privacy </a>
@@ -39,10 +36,11 @@
   background-position: center;
   transition: background 0.8s;
 }
+
 .ripple:hover {
-  background: #47a7f5 radial-gradient(circle, transparent 1%, #47a7f5 1%)
-    center/15000%;
+  background: #47a7f5 radial-gradient(circle, transparent 1%, #47a7f5 1%) center/15000%;
 }
+
 .ripple:active {
   background-color: #6eb9f7;
   background-size: 100%;
@@ -83,7 +81,7 @@ export default {
   setup() {
     const router = useRouter();
     const { toastSuccess, toastError } = useToast();
-    const { requestSocialLogin, setHook } = useArcanaWallet();
+    const { requestSocialLogin, fetchUserDetails, setHook } = useArcanaWallet();
 
     onMounted(async () => {
       document.title = "Login | Arcana Demo";
@@ -95,6 +93,7 @@ export default {
     async function onSignInClick() {
       try {
         await requestSocialLogin("google");
+        await fetchUserDetails();
         await router.push("/my-files");
         toastSuccess("Login Success");
       } catch (e) {

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -1,4 +1,4 @@
-import { AuthProvider, computeAddress } from "@arcana/auth";
+import { AuthProvider } from "@arcana/auth";
 
 const ARCANA_APP_ID = import.meta.env.VITE_ARCANA_APP_ID;
 const ARCANA_AUTH_NETWORK = import.meta.env.VITE_ARCANA_AUTH_NETWORK;
@@ -27,7 +27,11 @@ function createAuthService() {
   }
 
   async function requestPublicKey(email) {
-    return await auth.getPublicKey(email);
+    const publicKey = await auth.getPublicKey(email);
+    if (!publicKey.startsWith("0x")) {
+      return `0x${publicKey}`;
+    }
+    return publicKey;
   }
 
   async function requestSocialLogin(type) {
@@ -49,7 +53,6 @@ function createAuthService() {
   }
 
   return {
-    computeAddress,
     init,
     isLoggedIn,
     logout,

--- a/src/services/storage.service.js
+++ b/src/services/storage.service.js
@@ -75,12 +75,12 @@ function createStorageService() {
     await storage.files.revoke(fileDid, address);
   }
 
-  async function changeFileOwner(fileDid, address) {
+  async function changeOwner(fileDid, address) {
     await storage.files.changeOwner(fileDid, address);
   }
 
   return {
-    changeFileOwner,
+    changeOwner,
     download,
     getDownloadLimit,
     getSharedUsers,

--- a/src/use/arcanaStorage.js
+++ b/src/use/arcanaStorage.js
@@ -2,9 +2,9 @@ import bytes from "bytes";
 import { useStore } from "vuex";
 
 import StorageService from "../services/storage.service";
-import AuthService from "../services/auth.service";
 import useArcanaWallet from "../use/arcanaWallet";
 import useToast from "../use/toast";
+import { ethers } from "ethers";
 
 const FILE_SIZE_LIMIT = bytes("100MB");
 
@@ -162,7 +162,7 @@ function useArcanaStorage() {
       store.dispatch("showInlineLoader", "Sharing file");
 
       const publicKey = await requestPublicKey(email);
-      const address = AuthService.computeAddress(publicKey);
+      const address = ethers.utils.computeAddress(publicKey);
       await StorageService.share(file.fileId, address);
       toastSuccess(`Shared file successfully with ${email}`);
     } catch (error) {
@@ -209,7 +209,7 @@ function useArcanaStorage() {
       store.dispatch("showInlineLoader", "Transfering file");
 
       const publicKey = await requestPublicKey(email);
-      const address = AuthService.computeAddress(publicKey);
+      const address = ethers.utils.computeAddress(publicKey);
       await StorageService.changeOwner(fileToTransfer.fileId, address);
 
       let myFiles = [...store.getters.myFiles];


### PR DESCRIPTION
## Change Summary

- Updated auth sdk to `0.1.2-beta.17` and storage sdk to `0.3.8`
- Removed `computeAddress` from auth service (as it is removed from auth sdk) and used `ethers.utils.computeAddress` to do the same
- Renamed `changeFileOwner` frunction to `changeOwner` as there was discrepancy in the names used in service file and composable
- Added timeout to fetchUserDetails for already logged in user

NOTE: Some changes came because of formatter used in the editor. Will need to fix it later

## Checklist

- [x] The changes have been tested locally.
