### PR TITLE
Clean up and organise env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,13 @@
 # Arcana
-VITE_ARCANA_APP_ADDRESS="<your-arcana-app-address>"
-VITE_ARCANA_AUTH_NETWORK="<auth-network>"
-VITE_ARCANA_BLOCKCHAIN_ID="<auth-blockchain-id>"
+VITE_ARCANA_APP_ADDRESS="<arcana-app-address>"
+VITE_ARCANA_AUTH_NETWORK="<arcana-auth-network>"
+VITE_ARCANA_BLOCKCHAIN_ID="<arcana-blockchain-id>"
 VITE_ARCANA_EXPLORER_URL="<arcana-explorer-url>"
 VITE_ARCANA_GATEWAY_URL="<arcana-gateway-url>"
-VITE_ARCANA_WALLET_APP_MODE="<wallet-mode>"
+VITE_ARCANA_WALLET_APP_MODE="<arcana-wallet-mode>"
 
 # Google Analytics
-VITE_GOOGLE_ANALYTICS_ID="<your-google-analytics-id>"
+VITE_GOOGLE_ANALYTICS_ID="<google-analytics-id>"
 
 # Sentry
 VITE_SENTRY_DSN="<sentry-dsn>"

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,14 @@
+# Arcana
 VITE_ARCANA_APP_ADDRESS="<your-arcana-app-address>"
 VITE_ARCANA_AUTH_NETWORK="<auth-network>"
 VITE_ARCANA_BLOCKCHAIN_ID="<auth-blockchain-id>"
-VITE_GATEWAY_URL="<arcana-gateway-url>"
+VITE_ARCANA_EXPLORER_URL="<arcana-explorer-url>"
+VITE_ARCANA_GATEWAY_URL="<arcana-gateway-url>"
+VITE_ARCANA_WALLET_APP_MODE="<wallet-mode>"
+
+# Google Analytics
 VITE_GOOGLE_ANALYTICS_ID="<your-google-analytics-id>"
+
+# Sentry
 VITE_SENTRY_DSN="<sentry-dsn>"
 VITE_SENTRY_TRACING_ORIGINS="<sentry-tracing-origin>"
-VITE_ARCANA_WALLET_APP_MODE="<wallet-mode>"

--- a/src/components/FilesList.vue
+++ b/src/components/FilesList.vue
@@ -233,6 +233,8 @@ import {
 import DialogBox from "./DialogBox.vue";
 import useArcanaStorage from "../use/arcanaStorage";
 
+const ARCANA_EXPLORER_URL = import.meta.env.VITE_ARCANA_EXPLORER_URL;
+
 export default {
   name: "FilesList",
   props: ["files", "pageTitle"],
@@ -275,7 +277,7 @@ export default {
       icon: PencilAltIcon,
       command: (selectedFile) => {
         window.open(
-          "https://explorer.arcana.network/did/" + selectedFile.did,
+          `${ARCANA_EXPLORER_URL}/did/${selectedFile.did}`,
           "__blank"
         );
       },

--- a/src/services/storage.service.js
+++ b/src/services/storage.service.js
@@ -5,7 +5,7 @@ import {
 
 const ARCANA_APP_ADDRESS = import.meta.env.VITE_ARCANA_APP_ADDRESS;
 const BLOCKCHAIN_ID = import.meta.env.VITE_ARCANA_BLOCKCHAIN_ID;
-const GATEWAY_URL = import.meta.env.VITE_GATEWAY_URL;
+const GATEWAY_URL = import.meta.env.VITE_ARCANA_GATEWAY_URL;
 
 function createStorageService() {
   let storage;


### PR DESCRIPTION
Resolves [AR-4900](https://team-1624093970686.atlassian.net/browse/AR-4900).

## Change Summary

- Changes`VITE_GATEWAY_URL` to `VITE_ARCANA_GATEWAY_URL`.
- Add missing VITE_ARCANA_EXPLORER_URL variable in `.env.example` and on Netlify.
- Remove hard-coded explorer link in `FileList.vue`.
- Ensure all URLs work without a trailing slash.
- Group and sort env vars by category.

## Checklist

- [x] The changes have been tested locally.
